### PR TITLE
New functionality for ics2rem

### DIFF
--- a/remind.py
+++ b/remind.py
@@ -374,7 +374,7 @@ class Remind(object):
         return tag.replace(" ", "")[:48]
 
     def to_remind(self, vevent, label=None, priority=None, tags=None, tail=None,
-                  sep=" ", postdate=None):
+                  sep=" ", postdate=None, posttime=None):
         """Generate a Remind command from the given vevent"""
         remind = ['REM']
 
@@ -409,6 +409,10 @@ class Remind(object):
                 remind.append(vevent.dtstart.value.astimezone(self._localtz).strftime('AT %H:%M').replace(' 0', ' '))
             else:
                 remind.append(vevent.dtstart.value.strftime('AT %H:%M').replace(' 0', ' '))
+
+            if posttime:
+                remind.append(posttime)
+
             if duration.total_seconds() > 0:
                 remind.append('DURATION %d:%02d' % divmod(duration.total_seconds() / 60, 60))
 
@@ -433,13 +437,13 @@ class Remind(object):
         return ' '.join(remind) + '\n'
 
     def to_reminders(self, ical, label=None, priority=None, tags=None,
-                     tail=None, sep=" ", postdate=None):
+                     tail=None, sep=" ", postdate=None, posttime=None):
         """Return Remind commands for all events of a iCalendar"""
         if not hasattr(ical, 'vevent_list'):
             return ''
 
         reminders = [self.to_remind(vevent, label, priority, tags, tail, sep,
-                                    postdate)
+                                    postdate, posttime)
                         for vevent in ical.vevent_list]
         return ''.join(reminders)
 
@@ -545,6 +549,9 @@ def ics2rem():
     parser.add_argument('--postdate',
                         help='String to follow the date in every Remind entry. '
                         'Useful for entering "back" and "delta" fields (see man remind).')
+    parser.add_argument('--posttime',
+                        help='String to follow the time in every timed Remind entry. '
+                        'Useful for entering "tdelta" and "trepeat" fields (see man remind).')
     parser.add_argument('-z', '--zone', default='Europe/Berlin',
                         help='Timezone of Remind file (default: Europe/Berlin)')
     parser.add_argument('infile', nargs='?', type=FileType('r'), default=stdin,
@@ -561,5 +568,5 @@ def ics2rem():
     vobject = readOne(args.infile.read())
     rem = Remind(localtz=zone).to_reminders(
         vobject, args.label, args.priority, args.tag, args.tail, args.sep,
-        args.postdate)
+        args.postdate, args.posttime)
     args.outfile.write(rem)

--- a/remind.py
+++ b/remind.py
@@ -340,20 +340,26 @@ class Remind(object):
             msg.append(label)
 
         if hasattr(vevent, 'summary') and vevent.summary.value:
-            msg.append(vevent.summary.value.strip())
+            msg.append(Remind._rem_clean(vevent.summary.value))
         else:
             msg.append('empty reminder')
 
         if hasattr(vevent, 'location') and vevent.location.value:
-            msg.append('at %s' % vevent.location.value.strip())
+            msg.append('at %s' % Remind._rem_clean(vevent.location.value))
 
         if hasattr(vevent, 'description') and vevent.description.value:
             rem.append('%%"%s%%"' % ' '.join(msg))
-            rem.append(vevent.description.value.strip())
+            rem.append(Remind._rem_clean(vevent.description.value))
         else:
             rem.append(' '.join(msg))
 
-        return ' '.join(rem).replace('\n', '%_').replace('[', '["["]')
+        return ' '.join(rem)
+
+    @staticmethod
+    def _rem_clean(rem):
+        """Strip, transform newlines, and escape '[' in string so it's
+        acceptable as a remind entry."""
+        return rem.strip().replace('\n', '%_').replace('[', '["["]')
 
     @staticmethod
     def _abbr_tag(tag):

--- a/remind.py
+++ b/remind.py
@@ -374,7 +374,7 @@ class Remind(object):
         return tag.replace(" ", "")[:48]
 
     def to_remind(self, vevent, label=None, priority=None, tags=None, tail=None,
-                  sep=" "):
+                  sep=" ", postdate=None):
         """Generate a Remind command from the given vevent"""
         remind = ['REM']
 
@@ -384,6 +384,9 @@ class Remind(object):
 
         if not hasattr(vevent, 'rdate') and not isinstance(trigdates, str):
             remind.append(vevent.dtstart.value.strftime('%b %d %Y').replace(' 0', ' '))
+
+        if postdate:
+            remind.append(postdate)
 
         if priority:
             remind.append('PRIORITY %s' % priority)
@@ -430,12 +433,13 @@ class Remind(object):
         return ' '.join(remind) + '\n'
 
     def to_reminders(self, ical, label=None, priority=None, tags=None,
-                     tail=None, sep=" "):
+                     tail=None, sep=" ", postdate=None):
         """Return Remind commands for all events of a iCalendar"""
         if not hasattr(ical, 'vevent_list'):
             return ''
 
-        reminders = [self.to_remind(vevent, label, priority, tags, tail, sep)
+        reminders = [self.to_remind(vevent, label, priority, tags, tail, sep,
+                                    postdate)
                         for vevent in ical.vevent_list]
         return ''.join(reminders)
 
@@ -538,6 +542,9 @@ def ics2rem():
                         help='Text to append to every remind summary, following final %%"')
     parser.add_argument('--sep', default=" ",
                         help='String to separate summary (and tail) from description')
+    parser.add_argument('--postdate',
+                        help='String to follow the date in every Remind entry. '
+                        'Useful for entering "back" and "delta" fields (see man remind).')
     parser.add_argument('-z', '--zone', default='Europe/Berlin',
                         help='Timezone of Remind file (default: Europe/Berlin)')
     parser.add_argument('infile', nargs='?', type=FileType('r'), default=stdin,
@@ -553,5 +560,6 @@ def ics2rem():
 
     vobject = readOne(args.infile.read())
     rem = Remind(localtz=zone).to_reminders(
-        vobject, args.label, args.priority, args.tag, args.tail, args.sep)
+        vobject, args.label, args.priority, args.tag, args.tail, args.sep,
+        args.postdate)
     args.outfile.write(rem)


### PR DESCRIPTION
Add various functionality to ics2rem, including

- Add a tail (with optional separator) to every MSG, which is intended to transform
`%"<summary>%" <description>` to `%<summary>%" <tail><sep><description>`.
This allows one to insert things like ‘%b’ after the summary.
- Add a ‘postdate’ string, which follows the date trigger in every Remind entry. This is useful for adding deltas like ‘+2’.
- Add a ‘posttime’ string, which follows the time in every timed Remind entry. This is useful for adding deltas and repeats, like ‘+60 *15’.