### PR TITLE
Fix bug in --tag option

### DIFF
--- a/remind.py
+++ b/remind.py
@@ -566,7 +566,7 @@ class Remind:
             remind.append(trigdates)
 
         if tags:
-            remind.extend([f"TAG {Remind._abbr_tag(tag) for tag in tags}"])
+            remind.extend([f"TAG {Remind._abbr_tag(tag)}" for tag in tags])
 
         if hasattr(vevent, "categories_list"):
             for categories in vevent.categories_list:


### PR DESCRIPTION
The `--tag` option to `ics2rem` was producing incorrect output.  The generator expression needs to be outside the f-string - it was producing output containing "<generator object ...>"!