### PR TITLE
Use INFO string for location if it is an url

### DIFF
--- a/remind.py
+++ b/remind.py
@@ -213,6 +213,8 @@ class Remind:
         if groups:
             msg = groups[1]
             vevent.add("location").value = groups[2]
+        elif event["info"]["url"]:
+            vevent.add("location").value = event["info"]["url"]
 
         vevent.add("dtstamp").value = datetime.fromtimestamp(self._mtime)
         vevent.add("summary").value = msg
@@ -553,6 +555,10 @@ class Remind:
             for categories in vevent.categories_list:
                 for category in categories.value:
                     remind.append(f"TAG {Remind._abbr_tag(category)}")
+
+        if hasattr(vevent, "location") and vevent.location.value.startswith("http") and locations:
+            remind.append(f'INFO "url: {vevent.location.value}"')
+            locations = False
 
         remind.append(Remind._gen_msg(vevent, label, tail, sep, locations))
 


### PR DESCRIPTION
When converting from ics to rem and the location of an event is an url, write it as an INFO string. E.g. (split over multiple lines for clarity):

```
REM Sep 25 2025 AT 10:00 DURATION 1:00 TAG PUBLIC \
	INFO "url: https://example.com/" \
	MSG %"Message%"%_Description
```
This is useful for when using tkremind, as in this way it allows to open the link with `xdg-open` by middle-clicking the event. See [man-page](https://man.archlinux.org/man/tkremind.1.en#HYPERLINKS).

For completeness, the opposite is also done when converting from rem to ics. However a location specified with the `" at <location>"` syntax in the `MSG` will take precedence over the INFO string if both are present.